### PR TITLE
Fix a bug in replay buffer for n-step

### DIFF
--- a/hive/replays/efficient_replay.py
+++ b/hive/replays/efficient_replay.py
@@ -218,7 +218,7 @@ class EfficientCircularBuffer(BaseReplayBuffer):
             is_terminal = terminals
             trajectory_lengths = np.ones(batch_size)
         else:
-            is_terminal = terminals.any(axis=1)
+            is_terminal = terminals.any(axis=1).astype(int)
             trajectory_lengths = (
                 np.argmax(terminals.astype(bool), axis=1) + 1
             ) * is_terminal + self._n_step * (1 - is_terminal)


### PR DESCRIPTION
This is a short PR to return `batch["done"]` as int because otherwise this [line](https://github.com/chandar-lab/RLHive/blob/03dda7d890091bc020806dfe7f5fdab40bdae504/hive/agents/rainbow.py#L265) gives an error.  