### PR TITLE
Logging

### DIFF
--- a/hive/__init__.py
+++ b/hive/__init__.py
@@ -1,4 +1,10 @@
+import logging
 import os
+
+logging.basicConfig(
+    format="[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s",
+    level=logging.INFO,
+)
 
 from hive import agents, envs, replays, runners, utils
 from hive.utils.registry import Registrable, registry

--- a/hive/agents/__init__.py
+++ b/hive/agents/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from hive.agents import qnets
 from hive.agents.agent import Agent
 from hive.agents.dqn import DQNAgent
@@ -15,5 +17,7 @@ registry.register_all(
         "RandomAgent": RandomAgent,
     },
 )
+
+logging.info("Registered agents.")
 
 get_agent = getattr(registry, f"get_{Agent.type_name()}")

--- a/hive/agents/qnets/__init__.py
+++ b/hive/agents/qnets/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from hive.utils.registry import registry
 from hive.agents.qnets.atari import NatureAtariDQNModel
 from hive.agents.qnets.base import FunctionApproximator
@@ -12,5 +14,7 @@ registry.register_all(
         "NatureAtariDQNModel": FunctionApproximator(NatureAtariDQNModel),
     },
 )
+
+logging.info("Registered function approximators.")
 
 get_qnet = getattr(registry, f"get_{FunctionApproximator.type_name()}")

--- a/hive/agents/qnets/utils.py
+++ b/hive/agents/qnets/utils.py
@@ -1,3 +1,4 @@
+import logging
 import math
 
 import torch
@@ -137,5 +138,7 @@ registry.register_all(
         "variance_scaling": InitializationFn(variance_scaling_),
     },
 )
+
+logging.info("Registered PyTorch initialization functions.")
 
 get_optimizer_fn = getattr(registry, f"get_{InitializationFn.type_name()}")

--- a/hive/configs/gym/dqn.yml
+++ b/hive/configs/gym/dqn.yml
@@ -1,6 +1,6 @@
 run_name: &run_name 'gym-dqn'
 train_steps: 50000
-test_frequency: 200
+test_frequency: 5000
 test_episodes: 10
 max_steps_per_episode: 1000
 stack_size: &stack_size 1

--- a/hive/envs/__init__.py
+++ b/hive/envs/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from hive.envs.base import BaseEnv, ParallelEnv
 from hive.envs.env_spec import EnvSpec
 from hive.envs.gym_env import GymEnv
@@ -40,5 +42,7 @@ registry.register_all(
         "PettingZooEnv": PettingZooEnv,
     },
 )
+
+logging.info('Registered environments.')
 
 get_env = getattr(registry, f"get_{BaseEnv.type_name()}")

--- a/hive/replays/__init__.py
+++ b/hive/replays/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from hive.replays.circular_replay import CircularReplayBuffer, SimpleReplayBuffer
 from hive.replays.legal_moves_replay import LegalMovesBuffer
 from hive.replays.prioritized_replay import PrioritizedReplayBuffer
@@ -13,5 +14,7 @@ registry.register_all(
         "LegalMovesBuffer": LegalMovesBuffer,
     },
 )
+
+logging.info("Registered replays.")
 
 get_replay = getattr(registry, f"get_{BaseReplayBuffer.type_name()}")

--- a/hive/runners/base.py
+++ b/hive/runners/base.py
@@ -1,4 +1,6 @@
 from abc import ABC
+from asyncio.log import logger
+import logging
 from typing import List
 from hive.agents.agent import Agent
 from hive.envs.base import BaseEnv
@@ -124,6 +126,8 @@ class Runner(ABC):
     def run_training(self):
         """Run the training loop."""
         self.train_mode(True)
+        logging.info("Starting train loop")
+
         while self._train_schedule.get_value():
             # Run training episode
             if not self._training:
@@ -135,13 +139,20 @@ class Runner(ABC):
 
             # Run test episodes
             if self._run_testing:
+                logging.info(
+                    f"{self._train_schedule._steps}/"
+                    f"{self._train_schedule._flip_step} training steps completed."
+                )
+                logger.info("Running testing.")
                 test_metrics = self.run_testing()
                 self._logger.update_step("test")
                 self._logger.log_metrics(test_metrics, "test")
                 self._run_testing = False
+                logging.info(f"Testing results: {test_metrics}")
 
             # Save experiment state
             if self._save_experiment:
+                logger.info("Saving run.")
                 self._experiment_manager.save()
                 self._save_experiment = False
 

--- a/hive/runners/base.py
+++ b/hive/runners/base.py
@@ -1,10 +1,11 @@
+import logging
 from abc import ABC
 from asyncio.log import logger
-import logging
+import pprint
 from typing import List
+
 from hive.agents.agent import Agent
 from hive.envs.base import BaseEnv
-
 from hive.runners.utils import Metrics
 from hive.utils import schedule
 from hive.utils.experiment import Experiment
@@ -148,7 +149,7 @@ class Runner(ABC):
                 self._logger.update_step("test")
                 self._logger.log_metrics(test_metrics, "test")
                 self._run_testing = False
-                logging.info(f"Testing results: {test_metrics}")
+                logging.info(f"Testing results: {pprint.pformat(test_metrics)}")
 
             # Save experiment state
             if self._save_experiment:

--- a/hive/runners/multi_agent_loop.py
+++ b/hive/runners/multi_agent_loop.py
@@ -1,5 +1,7 @@
 import argparse
 import copy
+import logging
+import pprint
 
 from hive import agents as agent_lib
 from hive import envs
@@ -274,6 +276,11 @@ def main():
         args.logger_config,
     )
     runner = set_up_experiment(config)
+    logging.info(
+        f"Using config: \n{pprint.pformat(runner._experiment_manager._config, compact=True)}"
+    )
+    logging.info("Created runner. Starting run!")
+
     runner.run_training()
 
 

--- a/hive/runners/single_agent_loop.py
+++ b/hive/runners/single_agent_loop.py
@@ -1,6 +1,7 @@
 import argparse
 import copy
 import logging
+import pprint
 
 from hive import agents as agent_lib
 from hive import envs
@@ -210,7 +211,9 @@ def main():
         args.logger_config,
     )
     runner = set_up_experiment(config)
-    logging.info(f"Using config: {runner._experiment_manager._config}")
+    logging.info(
+        f"Using config: \n{pprint.pformat(runner._experiment_manager._config, compact=False)}"
+    )
     logging.info("Created runner. Starting run!")
 
     runner.run_training()

--- a/hive/runners/single_agent_loop.py
+++ b/hive/runners/single_agent_loop.py
@@ -1,5 +1,6 @@
 import argparse
 import copy
+import logging
 
 from hive import agents as agent_lib
 from hive import envs
@@ -209,6 +210,9 @@ def main():
         args.logger_config,
     )
     runner = set_up_experiment(config)
+    logging.info(f"Using config: {runner._experiment_manager._config}")
+    logging.info("Created runner. Starting run!")
+
     runner.run_training()
 
 

--- a/hive/utils/loggers.py
+++ b/hive/utils/loggers.py
@@ -1,5 +1,6 @@
 import abc
 import copy
+import logging
 import os
 from typing import List
 
@@ -449,5 +450,7 @@ registry.register_all(
         "CompositeLogger": CompositeLogger,
     },
 )
+
+logging.info("Registered loggers.")
 
 get_logger = getattr(registry, f"get_{Logger.type_name()}")

--- a/hive/utils/schedule.py
+++ b/hive/utils/schedule.py
@@ -1,4 +1,5 @@
 import abc
+import logging
 
 from hive.utils.registry import Registrable, registry
 
@@ -199,5 +200,7 @@ registry.register_all(
         "DoublePeriodicSchedule": DoublePeriodicSchedule,
     },
 )
+
+logging.info("Registered schedules.")
 
 get_schedule = getattr(registry, f"get_{Schedule.type_name()}")

--- a/hive/utils/torch_utils.py
+++ b/hive/utils/torch_utils.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import torch
 from torch import optim
@@ -193,6 +194,8 @@ registry.register_all(
     },
 )
 
+logging.info("Registered PyTorch optimizers.")
+
 registry.register_all(
     LossFn,
     {
@@ -217,6 +220,8 @@ registry.register_all(
         "TripletMarginLoss": LossFn(torch.nn.TripletMarginLoss),
     },
 )
+
+logging.info("Registered PyTorch losses.")
 
 get_optimizer_fn = getattr(registry, f"get_{OptimizerFn.type_name()}")
 get_loss_fn = getattr(registry, f"get_{LossFn.type_name()}")


### PR DESCRIPTION
Adds console logging to Hive. See attached output.

```
$ python -m hive.runners.single_agent_loop -p gym/dqn.yml
[INFO 2022-03-24 19:47:58,550 torch_utils.py:197] Registered PyTorch optimizers.
[INFO 2022-03-24 19:47:58,550 torch_utils.py:224] Registered PyTorch losses.
[INFO 2022-03-24 19:47:58,553 utils.py:142] Registered PyTorch initialization functions.
[INFO 2022-03-24 19:47:58,554 __init__.py:18] Registered function approximators.
[INFO 2022-03-24 19:47:58,557 __init__.py:18] Registered replays.
[INFO 2022-03-24 19:47:59,129 schedule.py:204] Registered schedules.
[INFO 2022-03-24 19:47:59,129 loggers.py:454] Registered loggers.
[INFO 2022-03-24 19:47:59,130 __init__.py:21] Registered agents.
[INFO 2022-03-24 19:47:59,633 __init__.py:46] Registered environments.
wandb: Currently logged in as: dapatil211 (use `wandb login --relogin` to force relogin)
wandb: wandb version 0.12.11 is available!  To upgrade, please run:
wandb:  $ pip install wandb --upgrade
wandb: Tracking run with wandb version 0.12.9
wandb: Syncing run gym-dqn
wandb:  View project at https://wandb.ai/dapatil211/Hive
wandb:  View run at https://wandb.ai/dapatil211/Hive/runs/323x6337
wandb: Run data is saved locally in /home/darshan/research/RLHive/wandb/run-20220324_194800-323x6337
wandb: Run `wandb offline` to turn off syncing.
[INFO 2022-03-24 19:48:07,404 single_agent_loop.py:214] Using config: 
{'agent': {'kwargs': {'act_dim': 2,
                      'batch_size': 128,
                      'device': 'cuda',
                      'discount_rate': 0.99,
                      'epsilon_schedule': {'kwargs': {'value': 0.1},
                                           'name': 'ConstantSchedule'},
                      'log_frequency': 100,
                      'logger': {},
                      'loss_fn': {'kwargs': {}, 'name': 'SmoothL1Loss'},
                      'min_replay_history': 500,
                      'obs_dim': (4,),
                      'optimizer_fn': {'kwargs': {}, 'name': 'Adam'},
                      'replay_buffer': {'kwargs': {'capacity': 1000,
                                                   'gamma': 0.99,
                                                   'observation_dtype': 'np.float64',
                                                   'observation_shape': (4,),
                                                   'stack_size': 1},
                                        'name': 'CircularReplayBuffer'},
                      'representation_net': {'kwargs': {'hidden_units': [256,
                                                                         256]},
                                             'name': 'MLPNetwork'},
                      'reward_clip': 1,
                      'target_net_update_schedule': {'kwargs': {'off_value': False,
                                                                'on_value': True,
                                                                'period': 100},
                                                     'name': 'PeriodicSchedule'},
                      'test_epsilon': 0.001,
                      'update_period_schedule': {'kwargs': {'off_value': False,
                                                            'on_value': True,
                                                            'period': 1},
                                                 'name': 'PeriodicSchedule'}},
           'name': 'DQNAgent'},
 'environment': {'kwargs': {'env_name': 'CartPole-v0'}, 'name': 'GymEnv'},
 'loggers': {'kwargs': {'logger_list': [{'kwargs': {}, 'name': 'ChompLogger'},
                                        {'kwargs': {'name': 'gym-dqn',
                                                    'project': 'Hive',
                                                    'resume': 'allow',
                                                    'start_method': 'fork'},
                                         'name': 'WandbLogger'}]},
             'name': 'CompositeLogger'},
 'max_steps_per_episode': 1000,
 'run_name': 'gym-dqn',
 'save_dir': 'experiment',
 'saving_schedule': {'kwargs': {'off_value': False,
                                'on_value': True,
                                'period': 10000},
                     'name': 'PeriodicSchedule'},
 'stack_size': 1,
 'test_episodes': 10,
 'test_frequency': 5000,
 'train_steps': 50000}
[INFO 2022-03-24 19:48:07,405 single_agent_loop.py:217] Created runner. Starting run!
[INFO 2022-03-24 19:48:07,405 base.py:130] Starting train loop
[INFO 2022-03-24 19:48:19,039 base.py:143] 5123/50000 training steps completed.
[INFO 2022-03-24 19:48:19,039 base.py:147] Running testing.
[INFO 2022-03-24 19:48:19,639 base.py:152] Testing results: {'0_episode_length': 220.0, '0_reward': 220.0, 'full_episode_length': 220.0}
[INFO 2022-03-24 19:48:31,254 base.py:143] 10009/50000 training steps completed.
[INFO 2022-03-24 19:48:31,254 base.py:147] Running testing.
[INFO 2022-03-24 19:48:31,708 base.py:152] Testing results: {'0_episode_length': 217.4, '0_reward': 217.4, 'full_episode_length': 217.4}
[INFO 2022-03-24 19:48:31,708 base.py:156] Saving run.
[INFO 2022-03-24 19:48:31,709 experiment.py:82] Saving the experiment at experiment/gym-dqn/current
[INFO 2022-03-24 19:48:42,861 base.py:143] 15013/50000 training steps completed.
[INFO 2022-03-24 19:48:42,861 base.py:147] Running testing.
[INFO 2022-03-24 19:48:43,242 base.py:152] Testing results: {'0_episode_length': 163.9, '0_reward': 163.9, 'full_episode_length': 163.9}
[INFO 2022-03-24 19:48:54,719 base.py:143] 20073/50000 training steps completed.
[INFO 2022-03-24 19:48:54,719 base.py:147] Running testing.
[INFO 2022-03-24 19:48:55,200 base.py:152] Testing results: {'0_episode_length': 220.0, '0_reward': 220.0, 'full_episode_length': 220.0}
[INFO 2022-03-24 19:48:55,200 base.py:156] Saving run.
[INFO 2022-03-24 19:48:55,201 experiment.py:82] Saving the experiment at experiment/gym-dqn/current
[INFO 2022-03-24 19:49:07,722 base.py:143] 25073/50000 training steps completed.
[INFO 2022-03-24 19:49:07,722 base.py:147] Running testing.
[INFO 2022-03-24 19:49:08,202 base.py:152] Testing results: {'0_episode_length': 220.0, '0_reward': 220.0, 'full_episode_length': 220.0}
[INFO 2022-03-24 19:49:19,683 base.py:143] 30121/50000 training steps completed.
[INFO 2022-03-24 19:49:19,683 base.py:147] Running testing.
[INFO 2022-03-24 19:49:20,162 base.py:152] Testing results: {'0_episode_length': 220.0, '0_reward': 220.0, 'full_episode_length': 220.0}
[INFO 2022-03-24 19:49:20,162 base.py:156] Saving run.
[INFO 2022-03-24 19:49:20,163 experiment.py:82] Saving the experiment at experiment/gym-dqn/current
[INFO 2022-03-24 19:49:31,406 base.py:143] 35177/50000 training steps completed.
[INFO 2022-03-24 19:49:31,406 base.py:147] Running testing.
[INFO 2022-03-24 19:49:31,870 base.py:152] Testing results: {'0_episode_length': 220.0, '0_reward': 220.0, 'full_episode_length': 220.0}
[INFO 2022-03-24 19:49:43,221 base.py:143] 40126/50000 training steps completed.
[INFO 2022-03-24 19:49:43,221 base.py:147] Running testing.
[INFO 2022-03-24 19:49:43,713 base.py:152] Testing results: {'0_episode_length': 220.0, '0_reward': 220.0, 'full_episode_length': 220.0}
[INFO 2022-03-24 19:49:43,713 base.py:156] Saving run.
[INFO 2022-03-24 19:49:43,714 experiment.py:82] Saving the experiment at experiment/gym-dqn/current
[INFO 2022-03-24 19:49:55,012 base.py:143] 45101/50000 training steps completed.
[INFO 2022-03-24 19:49:55,012 base.py:147] Running testing.
[INFO 2022-03-24 19:49:55,491 base.py:152] Testing results: {'0_episode_length': 220.0, '0_reward': 220.0, 'full_episode_length': 220.0}
[INFO 2022-03-24 19:50:06,749 base.py:143] 50164/50000 training steps completed.
[INFO 2022-03-24 19:50:06,749 base.py:147] Running testing.
[INFO 2022-03-24 19:50:07,232 base.py:152] Testing results: {'0_episode_length': 220.0, '0_reward': 220.0, 'full_episode_length': 220.0}
[INFO 2022-03-24 19:50:07,232 base.py:156] Saving run.
[INFO 2022-03-24 19:50:07,233 experiment.py:82] Saving the experiment at experiment/gym-dqn/current
[INFO 2022-03-24 19:50:07,736 experiment.py:82] Saving the experiment at experiment/gym-dqn/current

wandb: Waiting for W&B process to finish, PID 456977... (success).
wandb:                                                                                
wandb: Run history:
wandb:                   0/epsilon █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
wandb:                0/train_loss ▁▁▁▁▁▁▁▃▂▁▁▃▃▁▁▃▄▄▁▁▄▁▁▁▁▁▄▄█▁▁▁▂▄▃▁▁▁▅█
wandb:                0/train_qval ▁▁▁▂▃▃▄▄▅▅▅▆▆▆▆▇▇▇▇▇▇▇██████████▇███████
wandb:                      0_step ▁▁▁▁▂▂▂▂▂▂▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▆▇▇▇▇▇███
wandb:       test/0_episode_length ██▁████████
wandb:               test/0_reward ██▁████████
wandb:    test/full_episode_length ██▁████████
wandb:                   test_step ▁▁▁▁▁▂▂▂▂▃▃▃▃▃▃▃▃▄▄▄▅▅▅▅▆▆▆▆▆▆▆▆▇▇▇▇████
wandb:      train/0_episode_length ▁▂▁▂▁▅▆▇███▂▅███▇█████████████████▆█████
wandb:              train/0_reward ▁▂▁▂▁▅▆▇███▂▅███▇█████████████████▆█████
wandb:   train/full_episode_length ▁▂▁▂▁▅▆▇███▂▅███▇█████████████████▆█████
wandb:                  train_step ▁▁▁▁▂▂▂▂▂▂▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▆▇▇▇▇▇███
wandb: 
wandb: Run summary:
wandb:                   0/epsilon 0.1
wandb:                0/train_loss 0.78445
wandb:                0/train_qval 101.70953
wandb:                      0_step 50164
wandb:       test/0_episode_length 220.0
wandb:               test/0_reward 220.0
wandb:    test/full_episode_length 220.0
wandb:                   test_step 11
wandb:      train/0_episode_length 200
wandb:              train/0_reward 200.0
wandb:   train/full_episode_length 200
wandb:                  train_step 50164
wandb: 
wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 1 other file(s)
wandb: Synced gym-dqn: https://wandb.ai/dapatil211/Hive/runs/323x6337
wandb: Find logs at: ./wandb/run-20220324_194800-323x6337/logs/debug.log
wandb: 
```