### PR TITLE
Update linter.yml

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Pin version of Click to avoid issues with running Black
-        run: pip install click==8.04
+        run: pip install click==8.0.4
       - name: Black
         uses: psf/black@stable

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,5 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
+      - name: Pin version of Click to avoid issues with running Black
+        run: pip install click==8.04
       - name: Black
         uses: psf/black@stable


### PR DESCRIPTION
Black is having issues because the click package was updated (https://github.com/psf/black/issues/2964). The temporary fix is to pin the version of click so that the CI works properly. Eventually, when black pushes the fix, we can revert this. 