### PR TITLE
Add num_updates_per_train_step hyperparameter

### DIFF
--- a/hive/agents/dqn.py
+++ b/hive/agents/dqn.py
@@ -119,7 +119,7 @@ class DQNAgent(Agent):
         if replay_buffer is None:
             replay_buffer = CircularReplayBuffer
         self._replay_buffer = replay_buffer(observation_shape=self._obs_dim)
-        self._discount_rate = discount_rate ** n_step
+        self._discount_rate = discount_rate**n_step
         self._grad_clip = grad_clip
         self._reward_clip = reward_clip
         self._target_net_soft_update = target_net_soft_update

--- a/hive/agents/dqn.py
+++ b/hive/agents/dqn.py
@@ -119,7 +119,7 @@ class DQNAgent(Agent):
         if replay_buffer is None:
             replay_buffer = CircularReplayBuffer
         self._replay_buffer = replay_buffer(observation_shape=self._obs_dim)
-        self._discount_rate = discount_rate**n_step
+        self._discount_rate = discount_rate ** n_step
         self._grad_clip = grad_clip
         self._reward_clip = reward_clip
         self._target_net_soft_update = target_net_soft_update

--- a/hive/agents/dqn.py
+++ b/hive/agents/dqn.py
@@ -50,6 +50,7 @@ class DQNAgent(Agent):
         epsilon_schedule: Schedule = None,
         test_epsilon: float = 0.001,
         min_replay_history: int = 5000,
+        num_updates_per_train_step: int = 1,
         batch_size: int = 32,
         device="cpu",
         logger: Logger = None,
@@ -98,6 +99,8 @@ class DQNAgent(Agent):
                 to be used during testing phase.
             min_replay_history (int): How many observations to fill the replay buffer
                 with before starting to learn.
+            num_updates_per_train_step (int): indicates the number of consecutive times the agent needs to
+                do the backprop in each update step
             batch_size (int): The size of the batch sampled from the replay buffer
                 during learning.
             device: Device on which all computations should be run.
@@ -149,6 +152,7 @@ class DQNAgent(Agent):
 
         self._test_epsilon = test_epsilon
         self._learn_schedule = SwitchSchedule(False, True, min_replay_history)
+        self._num_updates_per_train_step = num_updates_per_train_step
 
         self._state = {"episode_start": True}
         self._training = False
@@ -287,38 +291,39 @@ class DQNAgent(Agent):
             and self._replay_buffer.size() > 0
             and self._update_period_schedule.update()
         ):
-            batch = self._replay_buffer.sample(batch_size=self._batch_size)
-            (
-                current_state_inputs,
-                next_state_inputs,
-                batch,
-            ) = self.preprocess_update_batch(batch)
+            for _ in range(self._num_updates_per_train_step):
+                batch = self._replay_buffer.sample(batch_size=self._batch_size)
+                (
+                    current_state_inputs,
+                    next_state_inputs,
+                    batch,
+                ) = self.preprocess_update_batch(batch)
 
-            # Compute predicted Q values
-            self._optimizer.zero_grad()
-            pred_qvals = self._qnet(*current_state_inputs)
-            actions = batch["action"].long()
-            pred_qvals = pred_qvals[torch.arange(pred_qvals.size(0)), actions]
+                # Compute predicted Q values
+                self._optimizer.zero_grad()
+                pred_qvals = self._qnet(*current_state_inputs)
+                actions = batch["action"].long()
+                pred_qvals = pred_qvals[torch.arange(pred_qvals.size(0)), actions]
 
-            # Compute 1-step Q targets
-            next_qvals = self._target_qnet(*next_state_inputs)
-            next_qvals, _ = torch.max(next_qvals, dim=1)
+                # Compute 1-step Q targets
+                next_qvals = self._target_qnet(*next_state_inputs)
+                next_qvals, _ = torch.max(next_qvals, dim=1)
 
-            q_targets = batch["reward"] + self._discount_rate * next_qvals * (
-                1 - batch["done"]
-            )
-
-            loss = self._loss_fn(pred_qvals, q_targets).mean()
-
-            if self._logger.should_log(self._timescale):
-                self._logger.log_scalar("train_loss", loss, self._timescale)
-
-            loss.backward()
-            if self._grad_clip is not None:
-                torch.nn.utils.clip_grad_value_(
-                    self._qnet.parameters(), self._grad_clip
+                q_targets = batch["reward"] + self._discount_rate * next_qvals * (
+                    1 - batch["done"]
                 )
-            self._optimizer.step()
+
+                loss = self._loss_fn(pred_qvals, q_targets).mean()
+
+                if self._logger.should_log(self._timescale):
+                    self._logger.log_scalar("train_loss", loss, self._timescale)
+
+                loss.backward()
+                if self._grad_clip is not None:
+                    torch.nn.utils.clip_grad_value_(
+                        self._qnet.parameters(), self._grad_clip
+                    )
+                self._optimizer.step()
 
         # Update target network
         if self._target_net_update_schedule.update():

--- a/hive/agents/rainbow.py
+++ b/hive/agents/rainbow.py
@@ -302,7 +302,10 @@ class RainbowDQNAgent(DQNAgent):
                     log_p = torch.log(probs)
                     with torch.no_grad():
                         target_prob = self.target_projection(
-                            next_state_inputs, next_action, batch["reward"], batch["done"]
+                            next_state_inputs,
+                            next_action,
+                            batch["reward"],
+                            batch["done"],
                         )
 
                     loss = -(target_prob * log_p).sum(-1)
@@ -311,7 +314,9 @@ class RainbowDQNAgent(DQNAgent):
                     pred_qvals = pred_qvals[torch.arange(pred_qvals.size(0)), actions]
 
                     next_qvals = self._target_qnet(*next_state_inputs)
-                    next_qvals = next_qvals[torch.arange(next_qvals.size(0)), next_action]
+                    next_qvals = next_qvals[
+                        torch.arange(next_qvals.size(0)), next_action
+                    ]
 
                     q_targets = batch["reward"] + self._discount_rate * next_qvals * (
                         1 - batch["done"]


### PR DESCRIPTION
Previously we did not have this hyperparameter. It's needed in the Atari100K benchmark for the OverTrainedRainbow. The reason for adding to the general algorithms is that I think it's kind of an important hyperparameter in RL algorithms in general.  I'll be glad to hear your comments on this.