### PR TITLE
activation functions added to registry and mlps

### DIFF
--- a/hive/agents/qnets/mlp.py
+++ b/hive/agents/qnets/mlp.py
@@ -1,11 +1,11 @@
 from functools import partial
 from typing import List, Tuple, Union
-from hive.utils.utils import ActivationFn
 
 import numpy as np
 import torch
 from torch import nn
 
+from hive.utils.utils import ActivationFn
 from hive.agents.qnets.noisy_linear import NoisyLinear
 
 

--- a/hive/agents/qnets/mlp.py
+++ b/hive/agents/qnets/mlp.py
@@ -1,5 +1,6 @@
 from functools import partial
 from typing import List, Tuple, Union
+from hive.utils.utils import ActivationFn
 
 import numpy as np
 import torch
@@ -20,6 +21,7 @@ class MLPNetwork(nn.Module):
         self,
         in_dim: Tuple[int],
         hidden_units: Union[int, List[int]] = 256,
+        activation_fn: ActivationFn = None,
         noisy: bool = False,
         std_init: float = 0.5,
     ):
@@ -36,11 +38,14 @@ class MLPNetwork(nn.Module):
         super().__init__()
         if isinstance(hidden_units, int):
             hidden_units = [hidden_units]
+        if activation_fn is None:
+            activation_fn = torch.nn.ReLU
+
         linear_fn = partial(NoisyLinear, std_init=std_init) if noisy else nn.Linear
-        modules = [linear_fn(np.prod(in_dim), hidden_units[0]), torch.nn.ReLU()]
+        modules = [linear_fn(np.prod(in_dim), hidden_units[0]), activation_fn()]
         for i in range(len(hidden_units) - 1):
             modules.append(linear_fn(hidden_units[i], hidden_units[i + 1]))
-            modules.append(torch.nn.ReLU())
+            modules.append(activation_fn())
         self.network = torch.nn.Sequential(*modules)
 
     def forward(self, x):

--- a/hive/agents/qnets/mlp.py
+++ b/hive/agents/qnets/mlp.py
@@ -5,8 +5,8 @@ import numpy as np
 import torch
 from torch import nn
 
-from hive.utils.utils import ActivationFn
 from hive.agents.qnets.noisy_linear import NoisyLinear
+from hive.utils.utils import ActivationFn
 
 
 class MLPNetwork(nn.Module):

--- a/hive/utils/torch_utils.py
+++ b/hive/utils/torch_utils.py
@@ -251,7 +251,7 @@ registry.register_all(
         "Softmax2d": torch.nn.Softmax2d,
         "LogSoftmax": torch.nn.LogSoftmax,
         "AdaptiveLogSoftmaxWithLoss": torch.nn.AdaptiveLogSoftmaxWithLoss,
-    }
+    },
 )
 
 get_optimizer_fn = getattr(registry, f"get_{OptimizerFn.type_name()}")

--- a/hive/utils/torch_utils.py
+++ b/hive/utils/torch_utils.py
@@ -3,7 +3,7 @@ import torch
 from torch import optim
 
 from hive.utils.registry import registry
-from hive.utils.utils import LossFn, OptimizerFn
+from hive.utils.utils import LossFn, OptimizerFn, ActivationFn
 
 
 def numpify(t):
@@ -218,5 +218,42 @@ registry.register_all(
     },
 )
 
+registry.register_all(
+    ActivationFn,
+    {
+        "ELU": torch.nn.ELU,
+        "Hardshrink": torch.nn.Hardshrink,
+        "Hardsigmoid": torch.nn.Hardsigmoid,
+        "Hardtanh": torch.nn.Hardtanh,
+        "Hardswish": torch.nn.Hardswish,
+        "LeakyReLU": torch.nn.LeakyReLU,
+        "LogSigmoid": torch.nn.LogSigmoid,
+        "MultiheadAttention": torch.nn.MultiheadAttention,
+        "PReLU": torch.nn.PReLU,
+        "ReLU": torch.nn.ReLU,
+        "ReLU6": torch.nn.ReLU6,
+        "RReLU": torch.nn.RReLU,
+        "SELU": torch.nn.SELU,
+        "CELU": torch.nn.CELU,
+        "GELU": torch.nn.GELU,
+        "Sigmoid": torch.nn.Sigmoid,
+        "SiLU": torch.nn.SiLU,
+        "Mish": torch.nn.Mish,
+        "Softplus": torch.nn.Softplus,
+        "Softshrink": torch.nn.Softshrink,
+        "Softsign": torch.nn.Softsign,
+        "Tanh": torch.nn.Tanh,
+        "Tanhshrink": torch.nn.Tanhshrink,
+        "Threshold": torch.nn.Threshold,
+        "GLU": torch.nn.GLU,
+        "Softmin": torch.nn.Softmin,
+        "Softmax": torch.nn.Softmax,
+        "Softmax2d": torch.nn.Softmax2d,
+        "LogSoftmax": torch.nn.LogSoftmax,
+        "AdaptiveLogSoftmaxWithLoss": torch.nn.AdaptiveLogSoftmaxWithLoss,
+    }
+)
+
 get_optimizer_fn = getattr(registry, f"get_{OptimizerFn.type_name()}")
 get_loss_fn = getattr(registry, f"get_{LossFn.type_name()}")
+get_activation_fn = getattr(registry, f"get_{ActivationFn.type_name()}")

--- a/hive/utils/utils.py
+++ b/hive/utils/utils.py
@@ -118,3 +118,18 @@ class LossFn(Registrable):
             "loss_fn"
         """
         return "loss_fn"
+
+class ActivationFn(Registrable):
+    """A wrapper for callables that produce activation functions.
+
+    These wrapped callables can be partially initialized through configuration
+    files or command line arguments.
+    """
+
+    @classmethod
+    def type_name(cls):
+        """
+        Returns:
+            "activation_fn"
+        """
+        return "activation_fn"

--- a/hive/utils/utils.py
+++ b/hive/utils/utils.py
@@ -119,6 +119,7 @@ class LossFn(Registrable):
         """
         return "loss_fn"
 
+
 class ActivationFn(Registrable):
     """A wrapper for callables that produce activation functions.
 


### PR DESCRIPTION
Pytorch activation functions added to the registry. Now, can be used as arguments when defining an MLP.

A sanity run on DQN using Tanh as the activation: https://wandb.ai/sriyash421/Hive/runs/d3jcxb3c?workspace=user-sriyash421

The config can be modified as this:
```
representation_net:
      name: 'MLPNetwork'
      kwargs:
        hidden_units: [256, 256]
        activation_fn:
          name: 'Tanh'

```