### PR TITLE
Move State stacking to inside agent

### DIFF
--- a/hive/agents/dqn.py
+++ b/hive/agents/dqn.py
@@ -1,5 +1,6 @@
 import copy
 import os
+from collections import deque
 
 import gymnasium as gym
 import numpy as np
@@ -13,6 +14,7 @@ from hive.agents.qnets.utils import (
     calculate_output_dim,
     create_init_weights_fn,
 )
+from hive.agents.utils import get_stacked_state
 from hive.replays import BaseReplayBuffer, CircularReplayBuffer
 from hive.utils.loggers import Logger, NullLogger
 from hive.utils.schedule import (
@@ -108,6 +110,7 @@ class DQNAgent(Agent):
         super().__init__(
             observation_space=observation_space, action_space=action_space, id=id
         )
+        self._stack_size = stack_size
         self._state_size = (
             stack_size * self._observation_space.shape[0],
             *self._observation_space.shape[1:],
@@ -124,6 +127,11 @@ class DQNAgent(Agent):
         self._replay_buffer = replay_buffer(
             observation_shape=self._observation_space.shape,
             observation_dtype=self._observation_space.dtype,
+            action_shape=self._action_space.shape,
+            action_dtype=self._action_space.dtype,
+            stack_size=stack_size,
+            gamma=discount_rate,
+            n_step=n_step,
         )
         self._discount_rate = discount_rate**n_step
         self._grad_clip = grad_clip
@@ -188,6 +196,17 @@ class DQNAgent(Agent):
         super().eval()
         self._qnet.eval()
         self._target_qnet.eval()
+
+    def preprocess_observation(self, observation, agent_traj_state):
+        if agent_traj_state is None:
+            observation_stack = deque(maxlen=self._stack_size - 1)
+        else:
+            observation_stack = agent_traj_state["observation_stack"]
+        state, observation_stack = get_stacked_state(
+            observation, observation_stack, self._stack_size
+        )
+        state = torch.tensor(state, device=self._device).unsqueeze(0).float()
+        return state, observation_stack
 
     def preprocess_update_info(self, update_info):
         """Preprocesses the :obj:`update_info` before it goes into the replay buffer.
@@ -254,12 +273,13 @@ class DQNAgent(Agent):
         else:
             epsilon = self._test_epsilon
 
+        state, observation_stack = self.preprocess_observation(
+            observation, agent_traj_state
+        )
+
         # Sample action. With epsilon probability choose random action,
         # otherwise select the action with the highest q-value.
-        observation = torch.tensor(
-            np.expand_dims(observation, axis=0), device=self._device
-        ).float()
-        qvals = self._qnet(observation)
+        qvals = self._qnet(state)
         if self._rng.random() < epsilon:
             action = self._rng.integers(self._action_space.n)
         else:
@@ -272,7 +292,8 @@ class DQNAgent(Agent):
             and agent_traj_state is None
         ):
             self._logger.log_scalar("train_qval", torch.max(qvals), self._timescale)
-            agent_traj_state = {}
+        observation_stack.append(observation)
+        agent_traj_state = {"observation_stack": observation_stack}
         return action, agent_traj_state
 
     def update(self, update_info, agent_traj_state=None):

--- a/hive/agents/utils.py
+++ b/hive/agents/utils.py
@@ -1,0 +1,56 @@
+import numpy as np
+import torch
+
+
+def get_stacked_state(observation, observation_stack, stack_size):
+    """Create a stacked state for the agent. The previous observations recorded
+    by this agent are stacked with the current observation. If not enough
+    observations have been recorded, zero arrays are appended.
+
+    Args:
+        observation: Current observation.
+    """
+
+    if stack_size == 1:
+        return observation, observation_stack
+    while len(observation_stack) < stack_size - 1:
+        observation_stack.append(zeros_like(observation))
+
+    stacked_observation = concatenate(list(observation_stack) + [observation])
+    return stacked_observation, observation_stack
+
+
+def zeros_like(x):
+    """Create a zero state like some state. This handles slightly more complex
+    objects such as lists and dictionaries of numpy arrays and torch Tensors.
+
+    Args:
+        x (np.ndarray | torch.Tensor | dict | list): State used to define
+            structure/state of zero state.
+    """
+    if isinstance(x, np.ndarray):
+        return np.zeros_like(x)
+    elif isinstance(x, torch.Tensor):
+        return torch.zeros_like(x)
+    elif isinstance(x, dict):
+        return {k: zeros_like(v) for k, v in x.items()}
+    elif isinstance(x, list):
+        return [zeros_like(item) for item in x]
+    else:
+        return 0
+
+
+def concatenate(xs):
+    """Concatenates numpy arrays or dictionaries of numpy arrays.
+
+    Args:
+        xs (list): List of objects to concatenate.
+    """
+
+    if len(xs) == 0:
+        return np.array([])
+
+    if isinstance(xs[0], dict):
+        return {k: np.concatenate([x[k] for x in xs], axis=0) for k in xs[0]}
+    else:
+        return np.concatenate(xs, axis=0)

--- a/hive/configs/atari/dqn.yml
+++ b/hive/configs/atari/dqn.yml
@@ -15,7 +15,6 @@ kwargs:
   test_frequency: 250000
   test_episodes: 10
   max_steps_per_episode: 27000
-  stack_size: &stack_size 4
   environment:
     name: 'AtariEnv'
     kwargs:
@@ -32,6 +31,7 @@ kwargs:
           strides: [4, 2, 1]
           paddings: [2, 2, 1]
           mlp_layers: [512]
+      stack_size: 4
       optimizer_fn:
         name: 'RMSpropTF'
         kwargs:
@@ -47,9 +47,7 @@ kwargs:
         name: 'CircularReplayBuffer'
         kwargs:
           capacity: 1000000
-          stack_size: *stack_size
-          gamma: &gamma .99
-      discount_rate: *gamma
+      discount_rate: .99
       reward_clip: 1
       update_period_schedule:
         name: 'PeriodicSchedule'

--- a/hive/configs/atari/drqn.yml
+++ b/hive/configs/atari/drqn.yml
@@ -47,9 +47,8 @@ agent:
       name: 'RecurrentReplayBuffer'
       kwargs:
         capacity: 1000000
-        gamma: &gamma .99
     max_seq_len: *max_seq_len
-    discount_rate: *gamma
+    discount_rate: .99
     reward_clip: 1
     update_period_schedule:
       name: 'PeriodicSchedule'

--- a/hive/configs/atari/rainbow.yml
+++ b/hive/configs/atari/rainbow.yml
@@ -15,7 +15,6 @@ kwargs:
   test_frequency: 250000
   test_episodes: 10
   max_steps_per_episode: 27000
-  stack_size: &stack_size 4
   environment:
     name: 'AtariEnv'
     kwargs:
@@ -32,6 +31,7 @@ kwargs:
           strides: [4, 2, 1]
           paddings: [2, 2, 1]
           mlp_layers: [512]
+      stack_size: 4
       optimizer_fn:
         name: 'Adam'
         kwargs:
@@ -43,15 +43,12 @@ kwargs:
           scale: 0.577350269
       loss_fn:
         name: "MSELoss"
-      n_step: &n_step 3
+      n_step: 3
       replay_buffer:
         name: 'PrioritizedReplayBuffer'
         kwargs:
           capacity: 1000000
-          stack_size: *stack_size
-          gamma: &gamma .99
-          n_step: *n_step
-      discount_rate: *gamma
+      discount_rate: .99
       reward_clip: 1
       update_period_schedule:
         name: 'PeriodicSchedule'

--- a/hive/configs/gym/dqn.yml
+++ b/hive/configs/gym/dqn.yml
@@ -15,7 +15,6 @@ kwargs:
   test_frequency: 200
   test_episodes: 10
   max_steps_per_episode: 1000
-  stack_size: &stack_size 1
   environment:
     name: 'GymEnv'
     kwargs:
@@ -27,6 +26,7 @@ kwargs:
         name: 'MLPNetwork'
         kwargs:
           hidden_units: [256, 256]
+      stack_size: 1
       optimizer_fn:
         name: 'Adam'
         kwargs: {}
@@ -35,11 +35,8 @@ kwargs:
       replay_buffer:
         name: 'CircularReplayBuffer'
         kwargs:
-          observation_dtype: np.float64
           capacity: 1000
-          stack_size: *stack_size
-          gamma: &gamma .99
-      discount_rate: *gamma
+      discount_rate: .99
       reward_clip: 1
       target_net_update_schedule:
         name: 'PeriodicSchedule'

--- a/hive/configs/gym/rainbow.yml
+++ b/hive/configs/gym/rainbow.yml
@@ -28,21 +28,17 @@ kwargs:
         name: 'MLPNetwork'
         kwargs:
           hidden_units: [256, 256]
+      stack_size: 1
       optimizer_fn:
         name: 'Adam'
         kwargs: {}
       loss_fn:
         name: "SmoothL1Loss"
-      n_step: &n_step 1
       replay_buffer:
         name: 'CircularReplayBuffer'
         kwargs:
-          observation_dtype: np.float64
           capacity: 10000
-          stack_size: *stack_size
-          gamma: &gamma .99
-          n_step: *n_step
-      discount_rate: *gamma
+      discount_rate: .99
       reward_clip: 1
       target_net_update_schedule:
         name: 'PeriodicSchedule'

--- a/hive/configs/hanabi/rainbow.yml
+++ b/hive/configs/hanabi/rainbow.yml
@@ -17,7 +17,6 @@ kwargs:
   test_episodes: 10
   self_play: True
   num_agents: &num_agents 2
-  stack_size: &stack_size 1
 
   # Environment config
   environment:
@@ -37,6 +36,7 @@ kwargs:
           name: 'MLPNetwork'
           kwargs:
             hidden_units: [512, 512]
+        stack_size: 1
         optimizer_fn:
           name: 'Adam'
           kwargs:
@@ -49,10 +49,7 @@ kwargs:
           name: 'LegalMovesBuffer'
           kwargs:
             capacity: 1000000
-            stack_size: *stack_size
-            action_dim: 20
             num_players_sharing_buffer: *num_agents
-            gamma: 0.99
         discount_rate: .99
         update_period_schedule:
           name: 'PeriodicSchedule'

--- a/hive/configs/marlgrid/dqn.yml
+++ b/hive/configs/marlgrid/dqn.yml
@@ -17,7 +17,6 @@ kwargs:
   test_episodes: 10
   self_play: False
   num_agents: &num_agents 3
-  stack_size: &stack_size 3
 
   # Environment config
   environment:
@@ -40,6 +39,7 @@ kwargs:
             strides: [ 4, 2, 1 ]
             paddings: [ 0, 1, 1 ]
             mlp_layers: [ 512 ]
+        stack_size: &stack_size 3
         optimizer_fn:
           name: 'Adam'
           kwargs: {}
@@ -48,7 +48,6 @@ kwargs:
           name: 'CircularReplayBuffer'
           kwargs:
             capacity: 10000
-            stack_size: *stack_size
         discount_rate: .9
         target_net_update_schedule:
           name: 'PeriodicSchedule'
@@ -77,6 +76,7 @@ kwargs:
             strides: [ 4, 2, 1 ]
             paddings: [ 0, 1, 1 ]
             mlp_layers: [ 512 ]
+        stack_size: *stack_size
         optimizer_fn:
           name: 'Adam'
           kwargs: {}
@@ -85,7 +85,6 @@ kwargs:
           name: 'CircularReplayBuffer'
           kwargs:
             capacity: 10000
-            stack_size: *stack_size
         discount_rate: .9
         target_net_update_schedule:
           name: 'PeriodicSchedule'

--- a/hive/configs/marlgrid/rainbow.yml
+++ b/hive/configs/marlgrid/rainbow.yml
@@ -17,7 +17,6 @@ kwargs:
   test_episodes: 10
   self_play: False
   num_agents: &num_agents 2
-  stack_size: &stack_size 2
 
   # Environment config
   environment:
@@ -40,6 +39,7 @@ kwargs:
             kernel_sizes: [ 8, 4, 3 ]
             strides: [ 4, 2, 1 ]
             paddings: [ 0, 1, 1 ]
+        stack_size: &stack_size 2
         optimizer_fn:
           name: 'Adam'
           kwargs:
@@ -50,7 +50,6 @@ kwargs:
           name: 'PrioritizedReplayBuffer'
           kwargs:
             capacity: 100000
-            stack_size: *stack_size
         discount_rate: .9
         target_net_update_schedule:
           name: 'PeriodicSchedule'
@@ -85,6 +84,7 @@ kwargs:
             kernel_sizes: [ 8, 4, 3 ]
             strides: [ 4, 2, 1 ]
             paddings: [ 0, 1, 1 ]
+        stack_size: *stack_size
         optimizer_fn:
           name: 'Adam'
           kwargs:
@@ -95,7 +95,6 @@ kwargs:
           name: 'PrioritizedReplayBuffer'
           kwargs:
             capacity: 100000
-            stack_size: *stack_size
         discount_rate: .9
         target_net_update_schedule:
           name: 'PeriodicSchedule'

--- a/hive/configs/minatar/rainbow.yml
+++ b/hive/configs/minatar/rainbow.yml
@@ -37,6 +37,7 @@ kwargs:
           strides: [1]
           paddings: [0]
           normalization_factor: 1
+      stack_size: 1
       optimizer_fn:
         name: 'Adam'
         kwargs:
@@ -47,14 +48,11 @@ kwargs:
       init_fn:
         name: "variance_scaling"
       id: 0
-      n_step: &n_step 3
+      n_step: 3
       replay_buffer:
         name: 'PrioritizedReplayBuffer'
         kwargs:
           capacity: 100000
-          stack_size: 1
-          n_step: *n_step
-          gamma: .99
       discount_rate: .99
       update_period_schedule:
         name: 'PeriodicSchedule'

--- a/hive/configs/minatar/rainbow_circular_buffer.yml
+++ b/hive/configs/minatar/rainbow_circular_buffer.yml
@@ -37,6 +37,7 @@ kwargs:
           strides: [1]
           paddings: [0]
           normalization_factor: 1
+      stack_size: 1
       optimizer_fn:
         name: 'Adam'
         kwargs:
@@ -47,14 +48,11 @@ kwargs:
       init_fn:
         name: "variance_scaling"
       id: 0
-      n_step: &n_step 1
+      n_step: 1
       replay_buffer:
         name: 'CircularReplayBuffer'
         kwargs:
           capacity: 100000
-          stack_size: 1
-          n_step: *n_step
-          gamma: .99
       discount_rate: .99
       update_period_schedule:
         name: 'PeriodicSchedule'

--- a/hive/configs/mujoco/td3.yml
+++ b/hive/configs/mujoco/td3.yml
@@ -3,7 +3,7 @@ kwargs:
   experiment_manager:
     name: 'Experiment'
     kwargs:
-      name: &run_name 'ddpg'
+      name: &run_name 'td3'
       save_dir: 'experiment'
       saving_schedule:
         name: 'PeriodicSchedule'
@@ -19,7 +19,7 @@ kwargs:
   environment:
     name: 'GymEnv'
     kwargs:
-      env_name: 'Hopper-v2'
+      env_name: 'Hopper-v4'
       
   agent:
     name: 'TD3'

--- a/hive/runners/multi_agent_loop.py
+++ b/hive/runners/multi_agent_loop.py
@@ -24,7 +24,6 @@ class MultiAgentRunner(Runner):
         eval_environment: BaseEnv = None,
         test_frequency: int = -1,
         test_episodes: int = 1,
-        stack_size: int = 1,
         self_play: bool = False,
         max_steps_per_episode: int = 1e9,
         seed: int = None,
@@ -48,7 +47,6 @@ class MultiAgentRunner(Runner):
                 episodes. If this is -1, testing is not run.
             test_episodes (int): How many episodes to run testing for duing each test
                 phase.
-            stack_size (int): The number of frames in an observation sent to an agent.
             self_play (bool): Whether this multiagent experiment is run in
                 self-play mode. In this mode, only the first agent in the list
                 of agents provided in the config is created. This agent performs
@@ -79,14 +77,14 @@ class MultiAgentRunner(Runner):
                 agent = agent_fn(
                     observation_space=env_spec.observation_space[idx],
                     action_space=env_spec.action_space[idx],
-                    stack_size=stack_size,
                     logger=logger,
                 )
                 agent_list.append(agent)
             else:
                 agent_list.append(copy.copy(agent_list[0]))
                 agent_list[-1]._id = f"{agent_list[0]._id}_{idx}"
-
+        if self_play:
+            agent_list[0]._id = f"{agent_list[0]._id}_{0}"
         # Set up experiment manager
         experiment_manager = experiment_manager()
 
@@ -101,7 +99,6 @@ class MultiAgentRunner(Runner):
             test_episodes=test_episodes,
             max_steps_per_episode=max_steps_per_episode,
         )
-        self._stack_size = stack_size
         self._self_play = self_play
 
     def run_one_step(
@@ -144,8 +141,7 @@ class MultiAgentRunner(Runner):
         else:
             transition_info.start_agent(agent)
 
-        stacked_observation = transition_info.get_stacked_state(agent, observation)
-        action, agent_traj_state = agent.act(stacked_observation, agent_traj_state)
+        action, agent_traj_state = agent.act(observation, agent_traj_state)
         (
             next_observation,
             reward,
@@ -216,7 +212,7 @@ class MultiAgentRunner(Runner):
         """
         episode_metrics = self.create_episode_metrics()
         observation, turn = environment.reset()
-        transition_info = TransitionInfo(self._agents, self._stack_size)
+        transition_info = TransitionInfo(self._agents)
         steps = 0
         agent_traj_states = [None] * len(self._agents)
         terminated, truncated = False, False

--- a/tests/hive/runners/test_sa_loop.py
+++ b/tests/hive/runners/test_sa_loop.py
@@ -118,7 +118,6 @@ def test_run_step(initial_runner):
         single_agent_loop._train_environment,
         observation,
         episode_metrics,
-        TransitionInfo(single_agent_loop._agents, single_agent_loop._stack_size),
         None,
     )
     assert episode_metrics[agent.id]["episode_length"] == 1


### PR DESCRIPTION
This allows us to only have a single parameter to control state stacking, inside the agent, rather than having to put it in the runner and the agent. It makes the runner responsibilities a bit clearer.

I also updated the configs to make use of the fact that some arguments don't need to be passed twice in the config, and can be done programmatically (eg discount_factor)